### PR TITLE
all: simplification

### DIFF
--- a/issue5_test.go
+++ b/issue5_test.go
@@ -25,7 +25,7 @@ func TestIssue5(t *testing.T) {
 	w := &bytes.Buffer{}
 	printer := NewNodePrinter(w, PrintOptionsLayout|PrintOptionsStyle|PrintOptionsChildren)
 	printer.Print(root)
-	got := string(w.Bytes())
+	got := w.String()
 	exp := `<div layout="width: 40; height: 40; top: 0; left: 0;" style="height: 100%; ">
   <div layout="width: 40; height: 40; top: 0; left: 0;" style="padding: 20px; "></div>
 </div>`

--- a/measure_mode_test.go
+++ b/measure_mode_test.go
@@ -49,8 +49,7 @@ func _measure2(node *Node,
 
 func TestExactly_measure_stretched_child_column(t *testing.T) {
 	constraintList := measureConstraintList{
-		length:      0,
-		constraints: make([]measureConstraint, 10, 10),
+		constraints: make([]measureConstraint, 10),
 	}
 
 	root := NewNode()
@@ -68,13 +67,11 @@ func TestExactly_measure_stretched_child_column(t *testing.T) {
 
 	assertFloatEqual(t, 100, constraintList.constraints[0].width)
 	assert.Equal(t, MeasureModeExactly, constraintList.constraints[0].widthMode)
-
 }
 
 func TestExactly_measure_stretched_child_row(t *testing.T) {
 	constraintList := measureConstraintList{
-		length:      0,
-		constraints: make([]measureConstraint, 10, 10),
+		constraints: make([]measureConstraint, 10),
 	}
 
 	root := NewNode()
@@ -93,13 +90,11 @@ func TestExactly_measure_stretched_child_row(t *testing.T) {
 
 	assertFloatEqual(t, 100, constraintList.constraints[0].height)
 	assert.Equal(t, MeasureModeExactly, constraintList.constraints[0].heightMode)
-
 }
 
 func TestAt_most_main_axis_column(t *testing.T) {
 	constraintList := measureConstraintList{
-		length:      0,
-		constraints: make([]measureConstraint, 10, 10),
+		constraints: make([]measureConstraint, 10),
 	}
 
 	root := NewNode()
@@ -117,13 +112,11 @@ func TestAt_most_main_axis_column(t *testing.T) {
 
 	assertFloatEqual(t, 100, constraintList.constraints[0].height)
 	assert.Equal(t, MeasureModeAtMost, constraintList.constraints[0].heightMode)
-
 }
 
 func TestAt_most_cross_axis_column(t *testing.T) {
 	constraintList := measureConstraintList{
-		length:      0,
-		constraints: make([]measureConstraint, 10, 10),
+		constraints: make([]measureConstraint, 10),
 	}
 
 	root := NewNode()
@@ -142,13 +135,11 @@ func TestAt_most_cross_axis_column(t *testing.T) {
 
 	assertFloatEqual(t, 100, constraintList.constraints[0].width)
 	assert.Equal(t, MeasureModeAtMost, constraintList.constraints[0].widthMode)
-
 }
 
 func TestAt_most_main_axis_row(t *testing.T) {
 	constraintList := measureConstraintList{
-		length:      0,
-		constraints: make([]measureConstraint, 10, 10),
+		constraints: make([]measureConstraint, 10),
 	}
 
 	root := NewNode()
@@ -167,13 +158,11 @@ func TestAt_most_main_axis_row(t *testing.T) {
 
 	assertFloatEqual(t, 100, constraintList.constraints[0].width)
 	assert.Equal(t, MeasureModeAtMost, constraintList.constraints[0].widthMode)
-
 }
 
 func TestAt_most_cross_axis_row(t *testing.T) {
 	constraintList := measureConstraintList{
-		length:      0,
-		constraints: make([]measureConstraint, 10, 10),
+		constraints: make([]measureConstraint, 10),
 	}
 
 	root := NewNode()
@@ -193,13 +182,11 @@ func TestAt_most_cross_axis_row(t *testing.T) {
 
 	assertFloatEqual(t, 100, constraintList.constraints[0].height)
 	assert.Equal(t, MeasureModeAtMost, constraintList.constraints[0].heightMode)
-
 }
 
 func TestFlex_child(t *testing.T) {
 	constraintList := measureConstraintList{
-		length:      0,
-		constraints: make([]measureConstraint, 10, 10),
+		constraints: make([]measureConstraint, 10),
 	}
 
 	root := NewNode()
@@ -220,13 +207,11 @@ func TestFlex_child(t *testing.T) {
 
 	assertFloatEqual(t, 100, constraintList.constraints[1].height)
 	assert.Equal(t, MeasureModeExactly, constraintList.constraints[1].heightMode)
-
 }
 
 func TestFlex_child_with_flex_basis(t *testing.T) {
 	constraintList := measureConstraintList{
-		length:      0,
-		constraints: make([]measureConstraint, 10, 10),
+		constraints: make([]measureConstraint, 10),
 	}
 
 	root := NewNode()
@@ -245,13 +230,11 @@ func TestFlex_child_with_flex_basis(t *testing.T) {
 
 	assertFloatEqual(t, 100, constraintList.constraints[0].height)
 	assert.Equal(t, MeasureModeExactly, constraintList.constraints[0].heightMode)
-
 }
 
 func TestOverflow_scroll_column(t *testing.T) {
 	constraintList := measureConstraintList{
-		length:      0,
-		constraints: make([]measureConstraint, 10, 10),
+		constraints: make([]measureConstraint, 10),
 	}
 
 	root := NewNode()
@@ -274,13 +257,11 @@ func TestOverflow_scroll_column(t *testing.T) {
 
 	assert.True(t, FloatIsUndefined(constraintList.constraints[0].height))
 	assert.Equal(t, MeasureModeUndefined, constraintList.constraints[0].heightMode)
-
 }
 
 func TestOverflow_scroll_row(t *testing.T) {
 	constraintList := measureConstraintList{
-		length:      0,
-		constraints: make([]measureConstraint, 10, 10),
+		constraints: make([]measureConstraint, 10),
 	}
 
 	root := NewNode()
@@ -304,5 +285,4 @@ func TestOverflow_scroll_row(t *testing.T) {
 
 	assertFloatEqual(t, 100, constraintList.constraints[0].height)
 	assert.Equal(t, MeasureModeAtMost, constraintList.constraints[0].heightMode)
-
 }

--- a/yoga.go
+++ b/yoga.go
@@ -916,14 +916,11 @@ func constrainMaxSizeForMode(node *Node, axis FlexDirection, parentAxisSize floa
 		} else {
 			*size = maxSize
 		}
-
-		break
 	case MeasureModeUndefined:
 		if !FloatIsUndefined(maxSize) {
 			*mode = MeasureModeAtMost
 			*size = maxSize
 		}
-		break
 	}
 }
 


### PR DESCRIPTION
 - don't use cap when it's equal to len
 - remove default value initialization
 - remove break from switch since it's default